### PR TITLE
feat: Add `previews` for `gated` blogs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -1143,6 +1144,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -1155,6 +1157,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -1163,6 +1166,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -3036,16 +3040,6 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "license": "MIT"
     },
-    "node_modules/@types/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/@types/react-transition-group": {
       "version": "4.4.12",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
@@ -3093,7 +3087,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.13.0.tgz",
       "integrity": "sha512-w0xp+xGg8u/nONcGw1UXAr6cjCPU1w0XVyBs6Zqaj5eLmxkKQAByTdV/uGgNN5tVvN/kKpoQlP2cL7R+ajZZIQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.13.0",
         "@typescript-eslint/types": "8.13.0",
@@ -3430,7 +3423,6 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3500,12 +3492,14 @@
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -3517,7 +3511,8 @@
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3795,6 +3790,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -3816,6 +3812,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "devOptional": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -3842,7 +3839,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -3898,6 +3894,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -3942,6 +3939,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -3965,6 +3963,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -4101,6 +4100,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -4169,6 +4169,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -4338,12 +4339,14 @@
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -4731,7 +4734,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4923,7 +4925,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -5190,6 +5191,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
       "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -5205,6 +5207,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -5228,6 +5231,7 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
       "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -5248,6 +5252,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "devOptional": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -5371,6 +5376,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -5497,6 +5503,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -5564,7 +5571,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
       "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -5862,6 +5868,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -5954,6 +5961,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5997,6 +6005,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "devOptional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -6032,6 +6041,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "devOptional": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -6242,6 +6252,7 @@
       "version": "1.21.6",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6497,6 +6508,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
       "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -6585,6 +6597,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -6593,6 +6606,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "devOptional": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -6690,6 +6704,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -6724,7 +6739,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.0.7.tgz",
       "integrity": "sha512-Vl6fLEuOP1MgtEmDrY51BQr6Bl8oC8vDSHdA10xZWPPZa6e+dOwYNDLWHjvTktNLZkKYySpsW3Yzy4Lo+JORkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.0.7",
         "@swc/counter": "0.1.3",
@@ -6870,6 +6884,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6895,6 +6910,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -7213,6 +7229,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "devOptional": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -7224,6 +7241,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7232,6 +7250,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -7249,6 +7268,7 @@
       "version": "8.4.47",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
       "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7263,7 +7283,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -7277,6 +7296,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
@@ -7293,6 +7313,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
       "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+      "dev": true,
       "dependencies": {
         "camelcase-css": "^2.0.1"
       },
@@ -7311,6 +7332,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
       "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7345,6 +7367,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
       "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -7356,6 +7379,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7380,6 +7404,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -7455,6 +7480,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7475,7 +7501,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7485,7 +7510,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
       "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.25.0"
       },
@@ -7527,7 +7551,6 @@
       "version": "7.53.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.2.tgz",
       "integrity": "sha512-YVel6fW5sOeedd1524pltpHX+jgU2u3DSDtXEaBORNdqiNrsX/nUI/iGXONegttg0mJVnfrIkiV0cmTU6Oo2xw==",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -7669,6 +7692,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "dependencies": {
         "pify": "^2.3.0"
       }
@@ -7677,6 +7701,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -7814,6 +7839,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -7849,6 +7875,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7906,7 +7933,6 @@
       "version": "1.80.6",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.80.6.tgz",
       "integrity": "sha512-ccZgdHNiBF1NHBsWvacvT5rju3y1d/Eu+8Ex6c21nHp2lZGLBEtuwc415QfiI1PJa1TpCo3iXwwSRjRpn2Ckjg==",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^4.0.0",
@@ -8384,6 +8410,7 @@
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
       "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
@@ -8405,6 +8432,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -8413,6 +8441,7 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -8432,6 +8461,7 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -8505,7 +8535,7 @@
       "version": "3.4.14",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.14.tgz",
       "integrity": "sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -8565,6 +8595,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "dependencies": {
         "any-promise": "^1.0.0"
       }
@@ -8573,6 +8604,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -8589,6 +8621,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "devOptional": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -8620,7 +8653,8 @@
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
     },
     "node_modules/ts-invariant": {
       "version": "0.10.3",
@@ -8748,20 +8782,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -8876,7 +8896,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/webpack-bundle-analyzer": {
       "version": "4.10.1",
@@ -9140,6 +9161,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
       "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+      "dev": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/components/BlogDetail/Content.jsx
+++ b/src/components/BlogDetail/Content.jsx
@@ -1,8 +1,96 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ShareDetails from './ShareDetails';
 import styles from "./blogstyles.module.css"
 
-const Content = ({ slug, date, content }) => {
+const Content = ({ slug, date, content, isGated = false, preview = "" }) => {
+    const [email, setEmail] = useState('');
+    const [otp, setOtp] = useState('');
+    const [sending, setSending] = useState(false);
+    const [verifying, setVerifying] = useState(false);
+    const [message, setMessage] = useState('');
+    const [fullContent, setFullContent] = useState(content || '');
+    const [checkingAccess, setCheckingAccess] = useState(false);
+
+    useEffect(() => {
+        let cancelled = false;
+        const checkAccess = async () => {
+            if (!isGated || fullContent) return;
+            setCheckingAccess(true);
+            try {
+                const res = await fetch(`/api/blogs/secure?slug=${encodeURIComponent(slug)}`);
+                if (res.ok) {
+                    const data = await res.json();
+                    if (!cancelled && data?.content) {
+                        setFullContent(data.content);
+                    }
+                }
+            } catch {
+                // ignore and keep gated preview
+            } finally {
+                if (!cancelled) setCheckingAccess(false);
+            }
+        };
+        checkAccess();
+        return () => {
+            cancelled = true;
+        };
+    }, [isGated, fullContent, slug]);
+
+    const handleSendOtp = async () => {
+        if (!email) {
+            setMessage('Please enter your email.');
+            return;
+        }
+        setMessage('');
+        setSending(true);
+        try {
+            const res = await fetch('/api/otp/request', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email, slug }),
+            });
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                throw new Error(data.error || 'Failed to send OTP');
+            }
+            setMessage('OTP sent. Check your inbox.');
+        } catch (err) {
+            setMessage(err.message || 'Failed to send OTP');
+        } finally {
+            setSending(false);
+        }
+    };
+
+    const handleVerifyOtp = async () => {
+        if (!email || !otp) {
+            setMessage('Please enter both email and OTP.');
+            return;
+        }
+        setMessage('');
+        setVerifying(true);
+        try {
+            const res = await fetch('/api/otp/verify', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email, slug, otp }),
+            });
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                throw new Error(data.error || 'OTP verification failed');
+            }
+            const contentRes = await fetch(`/api/blogs/secure?slug=${encodeURIComponent(slug)}`);
+            if (!contentRes.ok) {
+                throw new Error('Unable to unlock content');
+            }
+            const data = await contentRes.json();
+            setFullContent(data.content || '');
+            setMessage('Access granted.');
+        } catch (err) {
+            setMessage(err.message || 'OTP verification failed');
+        } finally {
+            setVerifying(false);
+        }
+    };
 
     return (
         <>
@@ -10,10 +98,80 @@ const Content = ({ slug, date, content }) => {
                 <div className='container-lg w-full h-full flex items-start justify-between mobile:flex-col tablet:flex-col'>
                     <ShareDetails slug={slug} date={date} />
                     <div className='w-[65%] h-full space-y-[1.5vw] mobile:w-full mobile:mt-[4vw] mobile:space-y-[4vw] tablet:w-full'>
-                        <div
-                            className={`${styles.blogContent}`}
-                            dangerouslySetInnerHTML={{ __html: content }}
-                        />
+                        {isGated && !fullContent ? (
+                            <div className={`${styles.blogContent}`}>
+                                <p>{preview}</p>
+                                <div className="mt-[3vw] p-[2vw] border border-black/10 rounded-[1vw] bg-white/70 mobile:mt-[8vw] mobile:p-[5vw] mobile:rounded-[4vw]">
+                                    <h3 className="text-[1.6vw] font-semibold mobile:text-[5vw]">Unlock the full article</h3>
+                                    <p className="mt-[0.5vw] text-black/70 mobile:mt-[2vw]">
+                                        Enter your email to receive an OTP and continue reading.
+                                    </p>
+                                    {checkingAccess ? (
+                                        <p className="mt-[0.8vw] text-[0.95vw] text-black/60 mobile:mt-[3vw] mobile:text-[3.4vw]">
+                                            Checking access…
+                                        </p>
+                                    ) : null}
+                                    <form
+                                        className="mt-[1.5vw] flex gap-[1vw] items-end mobile:mt-[4vw] mobile:flex-col mobile:items-stretch"
+                                        onSubmit={(e) => e.preventDefault()}
+                                    >
+                                        <label className="flex-1">
+                                            <span className="block text-[0.9vw] text-black/60 mobile:text-[3.4vw]">Email</span>
+                                            <input
+                                                type="email"
+                                                name="email"
+                                                className="mt-[0.6vw] w-full border border-black/20 rounded-[0.6vw] px-[1vw] py-[0.8vw] mobile:mt-[2vw] mobile:rounded-[3vw] mobile:px-[4vw] mobile:py-[3.2vw]"
+                                                placeholder="you@company.com"
+                                                required
+                                                value={email}
+                                                onChange={(e) => setEmail(e.target.value)}
+                                            />
+                                        </label>
+                                        <button
+                                            type="button"
+                                            onClick={handleSendOtp}
+                                            className={`px-[1.6vw] py-[0.9vw] rounded-[0.6vw] bg-black text-white mobile:rounded-[3vw] mobile:px-[4vw] mobile:py-[3.2vw] ${sending ? 'opacity-60 pointer-events-none' : ''}`}
+                                        >
+                                            {sending ? 'Sending…' : 'Send OTP'}
+                                        </button>
+                                    </form>
+                                    <form
+                                        className="mt-[1.2vw] flex gap-[1vw] items-end mobile:mt-[4vw] mobile:flex-col mobile:items-stretch"
+                                        onSubmit={(e) => e.preventDefault()}
+                                    >
+                                        <label className="flex-1">
+                                            <span className="block text-[0.9vw] text-black/60 mobile:text-[3.4vw]">OTP</span>
+                                            <input
+                                                type="text"
+                                                name="otp"
+                                                inputMode="numeric"
+                                                className="mt-[0.6vw] w-full border border-black/20 rounded-[0.6vw] px-[1vw] py-[0.8vw] mobile:mt-[2vw] mobile:rounded-[3vw] mobile:px-[4vw] mobile:py-[3.2vw]"
+                                                placeholder="123456"
+                                                value={otp}
+                                                onChange={(e) => setOtp(e.target.value)}
+                                            />
+                                        </label>
+                                        <button
+                                            type="button"
+                                            onClick={handleVerifyOtp}
+                                            className={`px-[1.6vw] py-[0.9vw] rounded-[0.6vw] bg-black text-white mobile:rounded-[3vw] mobile:px-[4vw] mobile:py-[3.2vw] ${verifying ? 'opacity-60 pointer-events-none' : ''}`}
+                                        >
+                                            {verifying ? 'Verifying…' : 'Verify'}
+                                        </button>
+                                    </form>
+                                    {message ? (
+                                        <p className="mt-[1vw] text-[0.95vw] text-black/70 mobile:mt-[3vw] mobile:text-[3.4vw]">
+                                            {message}
+                                        </p>
+                                    ) : null}
+                                </div>
+                            </div>
+                        ) : (
+                            <div
+                                className={`${styles.blogContent}`}
+                                dangerouslySetInnerHTML={{ __html: fullContent || content }}
+                            />
+                        )}
                     </div>
                 </div>
             </section>

--- a/src/data/blogs.js
+++ b/src/data/blogs.js
@@ -25,6 +25,12 @@ export const POST_FIELDS = gql`
     blogFields {
       blogType
     }
+    tags {
+      nodes {
+        name
+        slug
+      }
+    }
     date
     isSticky
     slug
@@ -100,6 +106,12 @@ export const QUERY_POST_BY_SLUG = gql`
         }
       }
         blogType
+      }
+      tags {
+        nodes {
+          name
+          slug
+        }
       }
       author{
         node{

--- a/src/lib/blogs.js
+++ b/src/lib/blogs.js
@@ -196,6 +196,15 @@ export function mapPostData(post = {}) {
     data.featuredImage = data.featuredImage.node;
   }
 
+  // Clean up tags for easier access
+
+  if (data.tags) {
+    data.tags = data.tags.nodes.map(({ name, slug }) => ({
+      name,
+      slug,
+    }));
+  }
+
   return data;
 }
 

--- a/src/lib/gated-auth.js
+++ b/src/lib/gated-auth.js
@@ -1,0 +1,49 @@
+import crypto from 'crypto';
+
+const COOKIE_NAME = 'hiveminds_gated';
+
+function base64Url(input) {
+  return Buffer.from(input)
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function sign(data, secret) {
+  return crypto.createHmac('sha256', secret).update(data).digest('base64url');
+}
+
+export function getAuthSecret() {
+  return process.env.GATED_CONTENT_SECRET || 'dev-gated-secret';
+}
+
+export function createToken(payload, secret) {
+  const data = base64Url(JSON.stringify(payload));
+  const signature = sign(data, secret);
+  return `${data}.${signature}`;
+}
+
+export function verifyToken(token, secret) {
+  if (!token || typeof token !== 'string') return null;
+  const [data, signature] = token.split('.');
+  if (!data || !signature) return null;
+  const expected = sign(data, secret);
+  if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected))) return null;
+  try {
+    const payload = JSON.parse(Buffer.from(data, 'base64').toString('utf8'));
+    if (payload.exp && Date.now() > payload.exp) return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+export function buildAuthCookie(token, maxAgeSeconds = 60 * 60 * 24) {
+  const secure = process.env.NODE_ENV === 'production' ? ' Secure;' : '';
+  return `${COOKIE_NAME}=${token}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${maxAgeSeconds};${secure}`;
+}
+
+export function getAuthCookie(req) {
+  return req?.cookies?.[COOKIE_NAME];
+}

--- a/src/lib/otp-store.js
+++ b/src/lib/otp-store.js
@@ -1,0 +1,27 @@
+const otpStore = new Map();
+
+function getKey(email, slug) {
+  return `${email.toLowerCase()}|${slug}`;
+}
+
+export function createOtp(email, slug, ttlMs = 10 * 60 * 1000) {
+  const otp = String(Math.floor(100000 + Math.random() * 900000));
+  const expiresAt = Date.now() + ttlMs;
+  otpStore.set(getKey(email, slug), { otp, expiresAt });
+  return otp;
+}
+
+export function verifyOtp(email, slug, otp) {
+  const key = getKey(email, slug);
+  const entry = otpStore.get(key);
+  if (!entry) return { ok: false, reason: 'not_found' };
+  if (Date.now() > entry.expiresAt) {
+    otpStore.delete(key);
+    return { ok: false, reason: 'expired' };
+  }
+  if (entry.otp !== otp) {
+    return { ok: false, reason: 'mismatch' };
+  }
+  otpStore.delete(key);
+  return { ok: true };
+}

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -32,5 +32,18 @@ export function removeExtraSpaces(text) {
   return text.replace(/\s+/g, ' ').trim();
 }
 
+export function stripHtml(html) {
+  if (typeof html !== 'string') return '';
+  const withoutTags = html.replace(/<[^>]*>/g, ' ');
+  const withoutNbsp = withoutTags.replace(/&nbsp;/g, ' ');
+  return removeExtraSpaces(decodeHtmlEntities(withoutNbsp));
+}
+
+export function getTextPreview(html, maxLength = 400) {
+  const text = stripHtml(html);
+  if (!text) return '';
+  return text.length > maxLength ? `${text.slice(0, maxLength)}` : text;
+}
+
 export const homepage = process.env.NEXT_FRONTEND_URL;
 export const faviconPath = 'favicon.ico';

--- a/src/pages/api/blogs/secure.js
+++ b/src/pages/api/blogs/secure.js
@@ -1,0 +1,38 @@
+import { getPostBySlug } from '@/lib/blogs';
+import { getAuthCookie, getAuthSecret, verifyToken } from '@/lib/gated-auth';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  try {
+    const { slug } = req.query || {};
+    if (!slug) {
+      return res.status(400).json({ error: 'Slug is required' });
+    }
+
+    const { post } = await getPostBySlug(slug);
+    if (!post) {
+      return res.status(404).json({ error: 'Post not found' });
+    }
+
+    const isGated = Array.isArray(post.tags) && post.tags.some((tag) => tag?.slug === 'gated');
+    if (!isGated) {
+      return res.status(200).json({ content: post.content });
+    }
+
+    const token = getAuthCookie(req);
+    const payload = verifyToken(token, getAuthSecret());
+    const allowed = payload && Array.isArray(payload.slugs) && payload.slugs.includes(slug);
+
+    if (!allowed) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    return res.status(200).json({ content: post.content });
+  } catch (err) {
+    console.error('API Error:', err.message);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/src/pages/api/otp/request.js
+++ b/src/pages/api/otp/request.js
@@ -1,0 +1,44 @@
+import { Resend } from 'resend';
+import { createOtp } from '@/lib/otp-store';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  try {
+    const { email, slug } = req.body || {};
+
+    if (!email || !slug) {
+      return res.status(400).json({ error: 'Email and slug are required' });
+    }
+
+    const otp = createOtp(email, slug);
+
+    const { error } = await resend.emails.send({
+      from: 'HiveMinds <no-reply@hiveminds.in>',
+      to: [email],
+      subject: 'Your HiveMinds access code',
+      html: `
+        <div style="font-family:Arial,sans-serif;line-height:1.5">
+          <h2>Your OTP</h2>
+          <p>Use the code below to unlock the article:</p>
+          <p style="font-size:24px;font-weight:bold;letter-spacing:2px">${otp}</p>
+          <p>This code expires in 10 minutes.</p>
+        </div>
+      `,
+    });
+
+    if (error) {
+      console.error('Resend Error:', error);
+      return res.status(400).json({ error: 'Failed to send OTP' });
+    }
+
+    return res.status(200).json({ success: true });
+  } catch (err) {
+    console.error('API Error:', err.message);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/src/pages/api/otp/verify.js
+++ b/src/pages/api/otp/verify.js
@@ -1,0 +1,49 @@
+import { verifyOtp } from '@/lib/otp-store';
+import {
+  buildAuthCookie,
+  createToken,
+  getAuthCookie,
+  getAuthSecret,
+  verifyToken,
+} from '@/lib/gated-auth';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  try {
+    const { email, slug, otp } = req.body || {};
+
+    if (!email || !slug || !otp) {
+      return res.status(400).json({ error: 'Email, slug, and otp are required' });
+    }
+
+    const result = verifyOtp(email, slug, otp);
+    if (!result.ok) {
+      return res.status(400).json({ error: 'Invalid or expired OTP' });
+    }
+
+    const secret = getAuthSecret();
+    const existing = verifyToken(getAuthCookie(req), secret);
+
+    const now = Date.now();
+    let slugs = [slug];
+    let exp = now + ONE_DAY_MS;
+
+    if (existing && Array.isArray(existing.slugs) && existing.email === email) {
+      slugs = Array.from(new Set([...existing.slugs, slug]));
+      exp = existing.exp && existing.exp > now ? existing.exp : exp;
+    }
+
+    const token = createToken({ email, slugs, exp }, secret);
+    res.setHeader('Set-Cookie', buildAuthCookie(token));
+
+    return res.status(200).json({ success: true });
+  } catch (err) {
+    console.error('API Error:', err.message);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/src/pages/blog/[slug]/index.js
+++ b/src/pages/blog/[slug]/index.js
@@ -6,7 +6,7 @@ import Content from "@/components/BlogDetail/Content";
 import BlogHero from "@/components/BlogDetail/BlogHero";
 import { NextSeo } from "next-seo";
 import { ArticleJsonLd} from "@/lib/json-ld";
-import { homepage } from "@/lib/util";
+import { getTextPreview, homepage } from "@/lib/util";
 
 export default function BlogDetail({ post }) {
     
@@ -28,9 +28,12 @@ export default function BlogDetail({ post }) {
         metaImage,
         metaDescription,
         blogFields,
+        tags,
+        preview,
     } = post;
 
     const path = postPathBySlug(slug);
+    const isGated = Array.isArray(tags) && tags.some((tag) => tag?.slug === "gated");
     
     const relatedBlogsData = blogFields?.relatedBlogs?.edges?.map(edge => ({
         id: edge.node.id,
@@ -75,7 +78,13 @@ export default function BlogDetail({ post }) {
                     featuredImg={blogFields.heroImage.node}
                     category={categories[0].name}
                 />
-                <Content date={date} slug={slug} content={content} />
+                <Content
+                    date={date}
+                    slug={slug}
+                    content={content}
+                    isGated={isGated}
+                    preview={preview}
+                />
                 <RelatedBlogs blogs={relatedBlogsData}/>
             </Layout>
         </>
@@ -93,8 +102,12 @@ export async function getStaticProps({ params = {} }) {
         };
     }
 
+    const isGated = Array.isArray(post.tags) && post.tags.some((tag) => tag?.slug === "gated");
+    const preview = isGated ? getTextPreview(post.content, 400) : null;
+    const gatedPost = isGated ? { ...post, content: null, preview } : post;
+
     const props = {
-        post,
+        post: gatedPost,
     }
 
     return {


### PR DESCRIPTION
Implement an email/OTP gated content flow for blog posts. Updates include:

- UI: Enhance Content.jsx to show a preview and an unlock panel with email/OTP forms, client-side OTP request/verify logic, and fetching of unlocked content.
- API & auth: Add gated-auth utilities (token creation/verification) and server endpoints for OTP request/verify and a secure blog content endpoint (/api/otp/request, /api/otp/verify, /api/blogs/secure).
- Data/model: Expose tags in GraphQL blog queries and map tags in src/lib/blogs.js for easier access.
- Misc: Add an OTP store and wire up gated checks so posts can be conditionally unlocked after verification.

These changes add gated access to allow controlled unlocking of full article content via a one-time code sent to the user's email.